### PR TITLE
set up pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+
+exclude: 'migrations|.git'
+default_stages: [commit]
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+
+  - repo: https://github.com/pre-commit/mirrors-jshint
+    rev: v2.13.6
+    hooks:
+      - id: jshint
+
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.0.277'
+    hooks:
+      - id: ruff
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: [ "--config=setup.cfg" ]
+        additional_dependencies: [ flake8-isort ]

--- a/app/dev_requirements.txt
+++ b/app/dev_requirements.txt
@@ -3,3 +3,4 @@ click==8.0.3
 libsass
 django-compressor
 django-sass-processor
+pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+
+[tool.ruff]
+line-length = 120
+select = ["ALL"]
+exclude = [
+  "manage.py",
+]
+ignore = [
+  "I001",    # Import block is un-sorted or un-formatted (done by isort)
+  "D203",    # 1 blank line required before class docstring
+  "D212",    # Multi-line docstring summary should start at the first line pydocstyle
+  "ANN101",  # Missing type annotation for `self` in method
+  "ANN102",  # Missing type annotation for `cls` in classmethod
+  "ANN003",  # Missing type annotation for `**kwargs`
+  "EM102",   # Exception must not use an f-string literal, assign to variable first
+  "TRY003",  # Avoid specifying long messages outside the exception class
+  "S101",    # Use of `assert` detected
+  "UP007",   # Use `X | Y` for type annotations
+  "B905",    # `zip()` without an explicit `strict=` parameter
+  "FIX001",  # Line contains FIXME
+  "FIX002",  # Line contains TODO
+  "RET504",  # Unnecessary variable assignment before `return` statement
+  "G004",    # Logging statement uses f-string
+  "PD011",   # Use `.to_numpy()` instead of `.values`  (does not work out of the box)
+  "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
+  "UP038",   # (non-pep604-isinstance)
+]
+fix = true
+show-fixes = true
+unfixable = ["UP007", "I001"]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = [
+  "PLR2004", # Magic value used in comparison
+  "ANN201",  # Missing return type annotation for public function
+]
+"*/__init__.py" = [
+  "D104",  # Missing docstring in public package
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[flake8]
+max-line-length = 120
+exclude = .git,*/migrations/*
+max-complexity = 10
+per-file-ignores =test_*: S101
+
+
+[pycodestyle]
+max-line-length = 120
+exclude = .git,*/migrations/*
+
+[darglint]
+docstring_style=numpy


### PR DESCRIPTION
So far, I just copied Hendrik's configuration, removing unnecessary exclusion files and also removed the fail_fast option. We can see what hooks make sense for us to add/remove. 

to install
`pip install pre-commit` (also updated in dev-requirements file)
`pre-commit install`
