### PR TITLE
Make SHS consumers clear in demand plot

### DIFF
--- a/app/cp_nigeria/urls.py
+++ b/app/cp_nigeria/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path("ajax/consumergroup/form/<int:scen_id>", ajax_consumergroup_form, name="ajax_consumergroup_form"),
     path("ajax/load-timeseries", ajax_load_timeseries, name="ajax_load_timeseries"),
     path("ajax/update-graph", ajax_update_graph, name="ajax_update_graph"),
+    path("ajax/shs-tiers", ajax_shs_tiers, name="ajax_shs_tiers"),
     path("ajax/bmodel/infos", ajax_bmodel_infos, name="ajax_bmodel_infos"),
     path("ajax/community/details", get_community_details, name="get_community_details"),
     path("upload/timeseries", upload_demand_timeseries, name="upload_demand_timeseries"),

--- a/app/cp_nigeria/views.py
+++ b/app/cp_nigeria/views.py
@@ -332,6 +332,7 @@ def cpn_demand_params(request, proj_id, step_id=STEP_MAPPING["demand_profile"]):
                     form.fields[field].queryset = DemandTimeseries.objects.filter(consumer_type_id=consumer_type_id)
 
     page_information = "Please input user group data. This includes user type information about households, enterprises and facilities and predicted energy demand tiers as collected from survey data or available information about the community."
+    household_tiers = json.dumps([tier[1] for tier in HOUSEHOLD_TIERS])
 
     return render(
         request,
@@ -345,6 +346,7 @@ def cpn_demand_params(request, proj_id, step_id=STEP_MAPPING["demand_profile"]):
             "scen_id": project.scenario.id,
             "step_list": CPN_STEP_VERBOSE,
             "page_information": page_information,
+            "household_tiers": household_tiers,
         },
     )
 
@@ -1431,6 +1433,19 @@ def ajax_update_graph(request):
         timeseries_values = timeseries.get_values_with_unit("kWh")[:168]
 
         return JsonResponse({"timeseries_values": timeseries_values})
+
+    return JsonResponse({"error": request})
+
+
+@login_required
+@json_view
+@require_http_methods(["POST"])
+def ajax_shs_tiers(request):
+    if request.headers.get("x-requested-with") == "XMLHttpRequest":
+        shs_tier = request.POST.get("shs_tier")
+        excluded_tiers = get_shs_threshold(shs_tier)
+
+        return JsonResponse({"excluded_tiers": excluded_tiers})
 
     return JsonResponse({"error": request})
 

--- a/app/static/js/update_demand_graph.js
+++ b/app/static/js/update_demand_graph.js
@@ -153,8 +153,8 @@ function initialPlot () {
             }
 
 
-// data variable to check which traces are already in the graph
-var data = [];
+// traces variable to check which traces are already in the graph
+var traces = [];
 // update graph
 function updateGraph (newDemand, consumerGroupDemandName, formId){
         console.log('updating graph for consumergroup: ' + consumerGroupDemandName);
@@ -169,10 +169,10 @@ function updateGraph (newDemand, consumerGroupDemandName, formId){
 
         //check if trace already exists in the plot
         var existingTrace = false;
-        for (var i = 0; i < data.length; i++) {
-            if (data[i].formId === formId) {
+        for (var i = 0; i < traces.length; i++) {
+            if (traces[i].formId === formId) {
                 existingTrace = true;
-                data[i].y = newDemand;
+                traces[i].y = newDemand;
                 traceIndex = i+1;
                 break;
                 }
@@ -186,7 +186,7 @@ function updateGraph (newDemand, consumerGroupDemandName, formId){
         // add the new consumer group to the plot
             console.log('adding new trace');
             Plotly.addTraces(plot_div, trace);
-            data.push(trace);
+            traces.push(trace);
         }
 
         // save index of household traces (for updating SHS tiers and plot without looping through all traces)
@@ -194,7 +194,7 @@ function updateGraph (newDemand, consumerGroupDemandName, formId){
             if (existingTrace) {
             householdTraces[traceIndex] = consumerGroupDemandName;
             } else {
-            householdTraces[data.length] = consumerGroupDemandName;
+            householdTraces[traces.length] = consumerGroupDemandName;
             }
             updateSHSTraces();
         }
@@ -210,8 +210,8 @@ function updateGraph (newDemand, consumerGroupDemandName, formId){
 
 function updateKeyParams() {
     totalDemand = Array(168).fill(0);
-    for (var i = 0; i < data.length; i++) {
-        totalDemand = totalDemand.map((e, j) => e + data[i].y[j]);  // jshint ignore:line
+    for (var i = 0; i < traces.length; i++) {
+        totalDemand = totalDemand.map((e, j) => e + traces[i].y[j]);  // jshint ignore:line
     }
     var peakDemand = Math.max(...totalDemand);
     var avgDaily = totalDemand.reduce((partialSum, a) => partialSum + a, 0) / 7;

--- a/app/static/js/update_demand_graph.js
+++ b/app/static/js/update_demand_graph.js
@@ -221,7 +221,7 @@ function updateKeyParams() {
 
 function deleteTrace(consumerGroupId) {
     var formId = consumerGroupId.split('-')[1];
-    var traceIndex = parseInt(formId)+1;
+    var traceIndex = traces.findIndex(item => item.formId === formId) + 1;
     console.log("hiding trace index: " + traceIndex);
     var plot_div = document.getElementById('demand-aggregate');
 

--- a/app/templates/cp_nigeria/steps/scenario_demand.html
+++ b/app/templates/cp_nigeria/steps/scenario_demand.html
@@ -10,7 +10,8 @@
     const csrfToken = `{{ csrf_token }}`;
 	const dropdownUrl = `{% url 'ajax_load_timeseries' %}`;
     const updateGraphUrl = `{% url 'ajax_update_graph' %}`;
-    const allowEdition = `{{ allow_edition }}`;
+    const getThresholdUrl = `{% url 'ajax_shs_tiers' %}`;
+	var householdTiers = {{ household_tiers | safe }};
 </script>
 <script src="{% static 'js/consumer_groups.js' %}"></script>
 <script src="{% static 'js/dependent_dropdown.js' %}"></script>
@@ -36,7 +37,7 @@
 						<form method="POST" id="consumer-group-form">
 							{% csrf_token %}
 							<p>
-								Edit SHS threshold (advanced)
+								Edit Solar Home System threshold (advanced)
 								<label class="switch" data-bs-toggle="collapse" data-bs-target="#SHSForm" for="SHSSwitch">
 									<input type="checkbox" id="SHSSwitch">
 									<span class="slider round"></span>

--- a/app/templates/cp_nigeria/steps/scenario_demand.html
+++ b/app/templates/cp_nigeria/steps/scenario_demand.html
@@ -5,7 +5,7 @@
 
 
 {% block start_body_scripts %}
-<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script src="https://cdn.plot.ly/plotly-2.27.1.min.js"></script>
 <script>
     const csrfToken = `{{ csrf_token }}`;
 	const dropdownUrl = `{% url 'ajax_load_timeseries' %}`;


### PR DESCRIPTION
closes #89. SHS consumers are now plotted with hatching and grouped in the plot. They can all be deselected from the plot at once when the group is clicked. 

This PR also fixes a bug that was sometimes targetting the wrong consumer group in the plot when deleting a group. 

