### PR TITLE
Set output page help texts

### DIFF
--- a/app/business_model/forms.py
+++ b/app/business_model/forms.py
@@ -156,7 +156,7 @@ class EquityDataForm(forms.ModelForm):
 
         if not include_shs:
             for field in self.fields:
-                if "shs" in field:
+                if "SHS" in field:
                     self.fields[field].widget = forms.HiddenInput()
                     self.fields[field].required = False
 

--- a/app/business_model/forms.py
+++ b/app/business_model/forms.py
@@ -156,7 +156,7 @@ class EquityDataForm(forms.ModelForm):
 
         if not include_shs:
             for field in self.fields:
-                if "SHS" in field:
+                if "shs" in field:
                     self.fields[field].widget = forms.HiddenInput()
                     self.fields[field].required = False
 

--- a/app/cp_nigeria/helpers.py
+++ b/app/cp_nigeria/helpers.py
@@ -91,18 +91,18 @@ def get_project_summary(project):
     currency_symbol = project.economic_data.currency_symbol
 
     project_summary = {
-        "Project name": f"{project.name}",
+        "project_name": f"{project.name}",
         # "Community name": f"{community_name}",
-        "Location": f"{project.latitude:.4f}°, {project.longitude:.4f}°",
-        "Annual energy production": f"{yearly_production:,.2f} kWh",
-        "Firm power output": f"{firm_power_output:,.2f} kW_firm",
-        "Renewable share": f"{renewable_share:.2f}%",
-        "Indicative total investment costs": f"{total_investments:,.2f} {currency_symbol}",
-        "Investment per kW_firm": f"{investment_per_kwfirm:,.2f} {currency_symbol}/kW_firm",
-        "Estimated tariff": f"{tariff:.2f} {currency_symbol}/kWh",
-        "Indicative Project Lifetime": f"{project_lifetime} years",
-        "Aspired business model": f"{bm_name}",
-        "Assumed exchange rate": f"{project.economic_data.exchange_rate} {currency_symbol}/USD",
+        "location": f"{project.latitude:.4f}°, {project.longitude:.4f}°",
+        "yearly_production": f"{yearly_production:,.2f} kWh",
+        # "Firm power output": f"{firm_power_output:,.2f} kW_firm",
+        "renewable_share": f"{renewable_share:.2f}%",
+        "total_investments": f"{total_investments:,.2f}",
+        # "Investment per kW_firm": f"{investment_per_kwfirm:,.2f} {currency_symbol}/kW_firm",
+        "tariff": f"{tariff:.2f} {currency_symbol}/kWh",
+        "project_lifetime": f"{project_lifetime}",
+        "bm_name": f"{bm_name}",
+        "exchange_rate": f"{project.economic_data.exchange_rate} {currency_symbol}/USD",
     }
     return project_summary
 
@@ -135,7 +135,7 @@ def get_aggregated_cgs(project):
     else:
         shs_consumers = None
 
-    results_dict["SHS"] = {}
+    results_dict["shs"] = {}
     total_demand_shs = 0
     total_consumers_shs = 0
 
@@ -168,9 +168,9 @@ def get_aggregated_cgs(project):
             results_dict[consumer_type]["total_demand"] = round(total_demand, 2)
             results_dict[consumer_type]["supply_source"] = "mini_grid"
 
-        results_dict["SHS"]["nr_consumers"] = total_consumers_shs
-        results_dict["SHS"]["total_demand"] = 0
-        results_dict["SHS"]["supply_source"] = "shs"
+        results_dict["shs"]["nr_consumers"] = total_consumers_shs
+        results_dict["shs"]["total_demand"] = 0
+        results_dict["shs"]["supply_source"] = "shs"
 
     return results_dict
 
@@ -289,7 +289,7 @@ class ReportHandler:
             hh_number=self.aggregated_cgs["households"]["nr_consumers"],
             ent_number=self.aggregated_cgs["enterprises"]["nr_consumers"],
             pf_number=self.aggregated_cgs["public"]["nr_consumers"],
-            shs_number=self.aggregated_cgs["SHS"]["nr_consumers"],
+            shs_number=self.aggregated_cgs["shs"]["nr_consumers"],
             shs_threshold=options.shs_threshold,
             system_assets=system_assets,
             system_capacity="XXXX (???what is the definition of system size???)",
@@ -519,7 +519,12 @@ class ReportHandler:
         # )
 
         # Add project summary table
-        self.add_dict_as_table(get_project_summary(self.project))
+        project_summary = get_project_summary(self.project)
+        summary_table = {}
+        for key in project_summary:
+            summary_table[OUTPUT_PARAMS[key]["verbose"]] = project_summary[key]
+
+        self.add_dict_as_table(summary_table)
 
         # Add project summary
         self.add_heading("Project summary", level=2)
@@ -1024,7 +1029,7 @@ class FinancialTool:
         """
         tenor = self.financial_params["loan_maturity"]
         grace_period = self.financial_params["grace_period"]
-        amount = self.financial_kpis["Initial loan amount"]
+        amount = self.financial_kpis["initial_loan_amount"]
         interest_rate = self.financial_params["debt_interest_MG"]
         debt_start = self.project_start
 
@@ -1042,7 +1047,7 @@ class FinancialTool:
         tenor = self.financial_params["loan_maturity"]
         debt_start = self.project_start + self.loan_assumptions["Cum. replacement years"]
         grace_period = self.financial_params["grace_period"]
-        amount = self.financial_kpis["Replacement loan amount"]
+        amount = self.financial_kpis["replacement_loan_amount"]
         interest_rate = self.financial_params["debt_interest_replacement"]
 
         return self.debt_service_table(
@@ -1146,11 +1151,11 @@ class FinancialTool:
             "Total costs [NGN]"
         ].sum()
         financial_kpis = {
-            "Total investment costs": gross_capex,
-            "Total equity": total_equity,
-            "Total grant": total_grant,
-            "Initial loan amount": initial_amount,
-            "Replacement loan amount": replacement_amount,
+            "total_investments": gross_capex,
+            "total_equity": total_equity,
+            "total_grant": total_grant,
+            "initial_loan_amount": initial_amount,
+            "replacement_loan_amount": replacement_amount,
         }
 
         return financial_kpis

--- a/app/cp_nigeria/views.py
+++ b/app/cp_nigeria/views.py
@@ -1437,7 +1437,7 @@ def cpn_kpi_results(request, proj_id=None):
             }
 
             table_headers = {}
-            headers = ["Value"]
+            headers = [""]
             for header in headers:
                 table_headers[header] = {}
                 table_headers[header]["verbose"] = header

--- a/app/cp_nigeria/views.py
+++ b/app/cp_nigeria/views.py
@@ -1156,18 +1156,18 @@ def cpn_outputs(request, proj_id, step_id=STEP_MAPPING["outputs"], complex=False
         no_grant_tariff = ft.tariff
         no_grant_kpis = ft.financial_kpis
 
-        comparison_kpi_df = pd.DataFrame([financial_kpis, no_grant_kpis], index=["With grant", "Without grant"]).T
-        comparison_kpi_df.loc["Estimated tariff per kWh"] = {
-            "With grant": tariff * ft.exchange_rate,
-            "Without grant": no_grant_tariff * ft.exchange_rate,
+        comparison_kpi_df = pd.DataFrame([financial_kpis, no_grant_kpis], index=["with_grant", "without_grant"]).T
+        comparison_kpi_df.loc["tariff"] = {
+            "with_grant": tariff * ft.exchange_rate,
+            "without_grant": no_grant_tariff * ft.exchange_rate,
         }
 
         help_texts = {
-            "Total investment costs": help_icon("All upfront investment costs"),
-            "Total equity": help_icon("Total equity help text"),
-            "Total grant": help_icon("Total grant help text"),
-            "Initial loan amount": help_icon("Initial loan needed to cover the initial investment costs"),
-            "Replacement loan amount": help_icon("Amount needed to replace the system components"),
+            "total_investments": help_icon("All upfront investment costs"),
+            "total_equity": help_icon("Total equity help text"),
+            "total_grant": help_icon("Total grant help text"),
+            "initial_loan_amount": help_icon("Initial loan needed to cover the initial investment costs"),
+            "replacement_loan_amount": help_icon("Amount needed to replace the system components"),
         }
 
         for k in help_texts:
@@ -1177,7 +1177,7 @@ def cpn_outputs(request, proj_id, step_id=STEP_MAPPING["outputs"], complex=False
         cgs_df = pd.DataFrame.from_dict(aggregated_cgs, orient="index")
         cgs_df.loc["total mini-grid"] = cgs_df[cgs_df["supply_source"] == "mini_grid"].sum()
         cgs_df.drop(columns=["supply_source"], inplace=True)
-        cgs_df.rename(columns={"total_demand": "total_demand (kWh)"}, inplace=True)
+        cgs_df.rename(columns={"total_demand": "total_demand"}, inplace=True)
         project_summary = get_project_summary(project)
     currency_symbol = project.economic_data.currency_symbol
     context = {

--- a/app/dashboard/models.py
+++ b/app/dashboard/models.py
@@ -973,11 +973,11 @@ def graph_timeseries_stacked_cpn(simulations, y_variables, energy_vector):
             label=Case(
                 When(
                     Q(oemof_type="storage") & Q(direction="out"),
-                    then=Concat("asset", Value(" charge")),
+                    then=Concat("asset", Value("_charge")),
                 ),
                 When(
                     Q(oemof_type="storage") & Q(direction="in"),
-                    then=Concat("asset", Value(" discharge")),
+                    then=Concat("asset", Value("_discharge")),
                 ),
                 default="asset",
             ),

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -1298,10 +1298,10 @@ def request_financial_kpi_table(request, scen_id):
     no_grant_tariff = ft.tariff
     no_grant_kpis = ft.financial_kpis
 
-    comparison_kpi_df = pd.DataFrame([financial_kpis, no_grant_kpis], index=["With grant", "Without grant"]).T
-    comparison_kpi_df.loc["Estimated tariff"] = {
-        "With grant": tariff * ft.exchange_rate,
-        "Without grant": no_grant_tariff * ft.exchange_rate,
+    comparison_kpi_df = pd.DataFrame([financial_kpis, no_grant_kpis], index=["with_grant", "without_grant"]).T
+    comparison_kpi_df.loc["tariff"] = {
+        "with_grant": tariff * ft.exchange_rate,
+        "without_grant": no_grant_tariff * ft.exchange_rate,
     }
 
     comparison_kpis = comparison_kpi_df.T.to_dict()

--- a/app/static/cpn_output_params.csv
+++ b/app/static/cpn_output_params.csv
@@ -1,0 +1,52 @@
+label,verbose,description,unit
+project_name,Project name,,
+location,Location,,
+yearly_production,Annual energy production,Estimated annual energy production of the mini-grid (including excess),kWh
+renewable_share,Renewable share,Share of the energy production that is provided from renewable sources,
+firm_output,Firm power output,Indication of the rough magnitude of a constant load that could be powered by the mini-grid,kW_firm
+total_investments,Total investment costs,Sum of all capital expenditures,currency
+tariff,Estimated tariff,"The estimated cost for the consumer, taking into account all capital and operational expenditures as well as financing costs over the project lifetime",currency/kWh
+project_lifetime,Project lifetime,Number of years the project is intended to be operational,years
+bm_name,Aspired business model,"The selected approach for the delivery of the mini-grid project. In this case, the business model refers to the determination of roles and responsibilities of project proponents in the fields of ownership, development and implementation, operation and maintenance and financing",
+exchange_rate,Assumed exchange rate,Price of the given currency in relation to USD,currency/USD
+total_equity,Total equity,"The sum of equity that is provided, e.g. by a mini-grid company and/or community energy cooperative",
+total_grant,Total grant,"The sum of grant financing that flows into the project from funding agencies",
+initial_loan_amount,Initial loan amount,The sum of debt borrowed from banks and financiers at the beginning of the mini-grid project to cover investment costs,
+replacement_loan_amount,Replacement loan amount,"The sum of debt borrowed from banks and financiers during the lifetime of the mini-grid project to cover larger replacement costs of assets, such as inverters, battery or diesel generator",
+shs,Solar home systems,Consumers assumed to be served by solar home systems instead of the mini-grid,
+households,Households,Households connected to the mini-grid,
+enterprises,Enterprises,"Enterprises connected to the mini-grid, including machinery",
+public,Public facilities,Public facilities connected to the mini-grid,
+nr_consumers,Number of consumers,,
+total_demand,Total demand,,kWh
+installed_capacity,Installed Capacity,Already existing capacity of asset,
+optimized_capacity,Optimized Capacity,Newly added capacity to satisfy demand,
+capex_initial,Initial investment,Total funds needed to buy the asset,currency
+fuel_costs_total,Total fuel costs,Fuel costs during the first year of operation,currency
+opex_total,Operational expenditures,Operational and maintenance costs during the first year of operation,currency
+battery,Battery,,
+pv_plant,Solar PV plant,,
+diesel_generator,Diesel generator,,
+inverter,Inverter,,
+costs,Costs,,currency
+ac_bus_excess_flow,Total excess solar PV generation,Excess solar PV electricity that may be fed into the storage,kW
+dc_bus_excess_flow,Unused electricity,Excess solar PV generation that is unused by the system,kW
+pv_plant_flow,Solar PV generation,Demand directly satisfied by the solar PV plant,kW
+battery_charge_flow,Battery charge,Battery charging from excess generation,kW
+battery_discharge_flow,Battery discharge,Demand satisfied by the storage system,kW
+electricity_demand_flow,Electricity demand,Total demand to be satisfied by the system,kW
+diesel_generator_flow,Diesel generator,Demand satisfied by the diesel generator,kW
+with_grant,With grant,Financial parameters assuming the given grant share provided by REA or similar institutions,
+without_grant,Without grant,Financial parameters assuming no grant ,
+Cash flow after debt service,Cash flow after debt service,The remaining cash flow from operating activities after the interest and debt service payments,
+Debt repayments,Debt repayments,"The process of paying back a lender, typically through pre-determined periodic payments until the original amount borrowed and interest payments are repaid",
+Debt interest payments,Debt interest payments,A periodic fee for being lent the money,
+Operating revenues net,Operating revenues net,"Revenues from operation after tax (VAT) payments. Operating revenues can include revenues from electricity sale, revenues from fees and revenues from excess power purchase",
+Operating expenses,Operating expenses,"Ongoing expenses for the operation of the mini-grid. These can include operation amd maintenance (O&M) costs of the PV system, management and bookkeeping, insurance, land lease, security on site, and diesel costs",
+Fix project costs,Fix project costs,"E.g. land purchase, planning and development costs",
+Insurances,Insurances,"Several uncontrollable risks may exist that can damage the mini-grid system and dimish revenues, such as extreme weather events, theft or technical defects. Against a periodical fee, insurances reimburse the mini-grid owner in such cases.",
+Labour and soft costs,Labour and soft costs,"E.g. the labour needed for the system installation, development expenditures (DEVEX), incl. feasibility studies, project management or any contingency costs",
+Logistics,Logistics,"Logistics include costs for shipping, customs clearance costs, costs for custom storage and local transport",
+Power supply system,Power supply system,"Purchase cost of the mini-grid assets (PV plant, battery and diesel generator)",
+Taxes,Taxes,"The Value Added Tax (VAT) is a consumption tax paid when goods are purchased and services rendered. VAT applies to all operating revenues of the mini-grid system",
+Transmission network,Transmission network,"Transmission network costs can include costs for the on-site transformer, the substation for grid connection and the grid-connection itself",

--- a/app/static/financial_tool/financial_parameters_list.csv
+++ b/app/static/financial_tool/financial_parameters_list.csv
@@ -11,7 +11,7 @@ capex_transmission_network,Grid connection,,Transmission network,207,currency/Mi
 costs_shipping,Shipping,,Logistics,20,currency/kWp_cap,,pv_plant_optimized_capacity
 costs_customs,Customs clearance costs,,Logistics,3,currency/kWp_cap,,pv_plant_optimized_capacity
 costs_storage,Costs for custom storage,,Logistics,2,currency/kWp_cap,,pv_plant_optimized_capacity
-costs_transport,Local transport,,Logistics,5,currency/kWp_cap,,pv_plant_optimized_capacity
+costs_transport,Local transporlabelt,,Logistics,5,currency/kWp_cap,,pv_plant_optimized_capacity
 costs_insurance_construction,Construction,,Insurances,20,currency/kWp_cap,,pv_plant_optimized_capacity
 costs_insurance_transport,Transportation,,Insurances,0,currency/kWp_cap,,pv_plant_optimized_capacity
 costs_insurance_policy,Political risk policy,,Insurances,0,currency/kWp_cap,,pv_plant_optimized_capacity

--- a/app/static/js/report_items.js
+++ b/app/static/js/report_items.js
@@ -572,7 +572,7 @@ function addTable(response, table_id="") {
         var tableHdr = document.createElement('th');
         tableHdr.class = "header_table"
         // omit unit if undefined
-        if (value.unit == undefined) {
+        if ((value.unit == undefined) || (value.unit == "")) {
             unit = " "
         }
         else {
@@ -597,8 +597,8 @@ function addTable(response, table_id="") {
         for (i=0; i < tableLength; ++i) {
             const tableDataCell = document.createElement('td');
             // omit unit if undefined
-            if (value.unit == undefined) {
-                unit = " "
+            if ((value.unit == undefined) || (value.unit == "")) {
+            unit = " "
             }
             else {
                 unit = ' (' + value.unit + ') '


### PR DESCRIPTION
Sets all of the output page help texts and does some minor formatting with the colors. The help texts for the plots appear upon hovering on the graph area because I could not manage to add the hover help icon to the trace names (I don't think it is possible to add an image). 

Before testing `python manage.py collectstatic` should be run. 